### PR TITLE
remove spaces from invoke command

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ docker exec -e "CORE_PEER_TLS_ENABLED=true" \
 -e "CORE_PEER_LOCALMSPID=$MSP" \
 -e "CORE_PEER_MSPCONFIGPATH=$MSP_PATH"  \
 -e "CORE_PEER_ADDRESS=$PEER" \
-cli peer chaincode invoke -o $ORDERER -C $CHANNEL -n $FOREXCHAINCODENAME    -c '{"Args":["createUpdateForexPair", "USD", "GBP", "0.8"]}' --cafile $CAFILE --tls
+cli peer chaincode invoke -o $ORDERER -C $CHANNEL -n $FOREXCHAINCODENAME -c '{"Args":["createUpdateForexPair", "USD", "GBP", "0.8"]}' --cafile $CAFILE --tls
 ```
 
 ### Query the Pair


### PR DESCRIPTION
i got this error when i first ran this command, and when i reran without the spaces it worked.  not sure it's related but just in case.  this is the error

```
Error: endorsement failure during invoke. chaincode result: <nil>
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
